### PR TITLE
Update traefik.yml.tpl for minor mistypes

### DIFF
--- a/deploy_package/compose/production/traefik/traefik.yml.tpl
+++ b/deploy_package/compose/production/traefik/traefik.yml.tpl
@@ -27,14 +27,14 @@ certificatesResolvers:
 
 http:
   routers:
-    web-secure-django:
+    web-secure-colander:
       rule: "Host(\"${COLANDER_FQDN}\")"
       entryPoints:
         - web-secure
       middlewares:
         - compress-http
         - csrf
-      service: django
+      service: colander
       tls:
         certResolver: letsencrypt
     web-secure-threatr:
@@ -59,9 +59,9 @@ http:
         certResolver: letsencrypt
 
   middlewares:
-  	compress-http:
-  	  # https://doc.traefik.io/traefik/middlewares/http/compress/
-	  compress: true
+    compress-http:
+      # https://doc.traefik.io/traefik/middlewares/http/compress/
+      compress: true
     csrf:
       # https://docs.traefik.io/master/middlewares/headers/#hostsproxyheaders
       # https://docs.djangoproject.com/en/dev/ref/csrf/#ajax


### PR DESCRIPTION
hi!
- removed some 'tab' chars from lines 62, 63 and 64 as tabs are illegal character in .yml files.
- in the http section of the treafik.yml the name and service 'django' was in place instead of 'colander'.
- 