### PR TITLE
Pin GitHub Actions to digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Build the Stack
         run:  docker-compose -f local.yml build
       - name: Run DB Migrations
@@ -55,14 +55,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -72,7 +72,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # generate Docker tags based on the following events/attributes
@@ -89,7 +89,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: ./compose/production/django/Dockerfile
@@ -104,14 +104,14 @@ jobs:
             annotation.org.opencontainers.image.revision="${{ github.sha }}"
       
       - name: Log into Docker Hub
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker Scout
         id: docker-scout
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@fc749439af4870e8f6feb592250ab728600d10a6 # v1
         with:
           command: cves,sbom
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_METADATA_OUTPUT_VERSION }}
@@ -124,7 +124,7 @@ jobs:
       - name: Upload SARIF result
         id: upload-sarif
         if: ${{ github.event_name != 'pull_request' }}
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@319cdb9fa619417d07cc37a964f0502bfbc5e8a9 # v3
         with:
           sarif_file: sarif.output.json
 
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Compress the deployment package
         run: tar czf deployment-package.tar.gz deploy_package
       - name: Release

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,11 +47,11 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@319cdb9fa619417d07cc37a964f0502bfbc5e8a9 # v3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -79,6 +79,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@319cdb9fa619417d07cc37a964f0502bfbc5e8a9 # v3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Hey there 👋

I work on an open source security project ([Frizbee](https://github.com/stacklok/frizbee)) that can automatically pin GitHub Actions to digests (instead of floating tags). 

The Frizbee team is trying to spread the word to open source maintainers about the need for this, because pinning your actions to commit hashes is the *only* way to get an immutable pointer to a specific revision. If an action's source code repo is compromised by a malicious actor, you'll still be referencing a known-good version and your project won't be at risk. 

The following PR pins your actions to their commit hash and it was done using the [frizbee](https://github.com/stacklok/frizbee) CLI. Frizbee also appends a comment so you can easily see which version this digest corresponds to.

Note that Dependabot supports updating pinned actions and will continue to update them.

If you liked it and also want to keep this consistent in case you add more unpinned actions in future, there's a [frizbee-action](https://github.com/stacklok/frizbee-action) which you can use to help automate this.

Thanks!
